### PR TITLE
Update release workflow for manual releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,25 +119,9 @@ jobs:
           echo "rm -d /.github/workflows/bin/temp/"
     
 
-      - name: release
-        uses: actions/create-release@v1
-        id: create_release
-        with:
-          draft: false
-          prerelease: false
-          release_name: QLC+ ${{ steps.set_version.outputs.version }}
-          tag_name: ${{ github.ref }}
-          body: |
-            ## 
-            
+      - name: Upload PDF asset to release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-      - name: upload pdf artifact
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./.github/workflows/bin/pdf/qlcplus-docs.pdf
-          asset_name: qlcplus-docs.pdf
-          asset_content_type: application/pdf
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.set_version.outputs.version }}" \
+            ./.github/workflows/bin/pdf/qlcplus-docs.pdf --clobber


### PR DESCRIPTION
## Summary
- update release workflow to rely on an already created GitHub release

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f7387d9f08325b7f499869eaa1c23