### PR TITLE
Support multi-language PDF builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,20 @@ on:
   push:
   pull_request:
 jobs:
+  detect-languages:
+    runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.set.outputs.langs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - id: set
+        run: |
+          langs=$(find pages -name "*_??.md" | sed -n 's/.*_\([a-z][a-z]\)\.md/\1/p' | sort -u | tr '\n' ' ')
+          langs="en $langs"
+          json="[\"$(echo $langs | sed 's/ /\",\"/g')\"]"
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
   check-spelling:
     runs-on: ubuntu-latest
     steps:
@@ -15,7 +29,11 @@ jobs:
           task_name: Markdown
 
   build-pdf:
+    needs: detect-languages
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lang: ${{ fromJSON(needs.detect-languages.outputs.langs) }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -34,7 +52,7 @@ jobs:
     - name: Run PowerShell script
       shell: pwsh
       run: |
-        ./scripts/Merge-MarkdownFiles.ps1
+        ./scripts/Merge-MarkdownFiles.ps1 -Lang ${{ matrix.lang }}
 
     - name: Fix logo and copy images to root directory for pandoc # images directory is deleted in "Cleanup temporary items" step
       run: |
@@ -122,11 +140,11 @@ jobs:
     - name: Upload-PDF
       uses: actions/upload-artifact@v4
       with:
-          name: qlcplus-docs-en-pdf
+          name: qlcplus-docs-${{ matrix.lang }}-pdf
           path: ./.github/workflows/bin/pdf/
 
     - name: Upload-Markdown
       uses: actions/upload-artifact@v4
       with:
-          name: qlcplus-docs-en-markdown
+          name: qlcplus-docs-${{ matrix.lang }}-markdown
           path: ./.github/workflows/bin/markdown/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,27 @@ permissions:
   contents: write
       
 jobs:
+  detect-languages:
+    runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.set.outputs.langs }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - id: set
+        run: |
+          langs=$(find pages -name "*_??.md" | sed -n 's/.*_\([a-z][a-z]\)\.md/\1/p' | sort -u | tr '\n' ' ')
+          langs="en $langs"
+          json="[\"$(echo $langs | sed 's/ /\",\"/g')\"]"
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
   build_release:
     name: build_release
+    needs: detect-languages
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lang: ${{ fromJSON(needs.detect-languages.outputs.langs) }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -48,7 +66,7 @@ jobs:
       - name: Run PowerShell script
         shell: pwsh
         run: |
-            ./scripts/Merge-MarkdownFiles.ps1
+            ./scripts/Merge-MarkdownFiles.ps1 -Lang ${{ matrix.lang }}
 
       - name: Fix logo
         run: |
@@ -126,6 +144,8 @@ jobs:
           sudo apt-get install -y ghostscript
           gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=./.github/workflows/bin/pdf/qlcplus-docs.pdf ./.github/workflows/bin/temp/titlepage.pdf ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
           echo "rm -d /.github/workflows/bin/temp/"
+      - name: Rename PDF
+        run: mv ./.github/workflows/bin/pdf/qlcplus-docs.pdf ./.github/workflows/bin/pdf/qlcplus-docs-${{ matrix.lang }}.pdf
     
 
       - name: Upload PDF asset to release
@@ -133,4 +153,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ steps.set_version.outputs.version }}" \
-            ./.github/workflows/bin/pdf/qlcplus-docs.pdf --clobber
+            ./.github/workflows/bin/pdf/qlcplus-docs-${{ matrix.lang }}.pdf --clobber


### PR DESCRIPTION
## Summary
- build docs PDF for all languages detected in repo
- detect languages in CI and run jobs for each
- let release workflow upload language-specific PDFs
- merge docs in `Merge-MarkdownFiles.ps1` based on language parameter

## Testing
- `yamllint .github/workflows/main.yml .github/workflows/release.yml`


------
https://chatgpt.com/codex/tasks/task_e_686f513ffcec8325985c2bfb67421a72