### PR TITLE
Add dynamic PDF builds for all languages

### DIFF
--- a/.github/actions/build-pdf/action.yml
+++ b/.github/actions/build-pdf/action.yml
@@ -42,7 +42,7 @@ runs:
       shell: bash
       run: |
         cp -r ./.github/workflows/bin/markdown/images ./images
-        sed -i '/!\[\](images\/qlcplus\.svg)/d' ./.github/workflows/bin/markdown/qlcplus-docs.md
+        sed -i '/!\[\](images\/qlcplus\.svg)/d' ./.github/workflows/bin/markdown/qlcplus-docs-${{ inputs.lang }}.md
     - name: Normalize image DPI
       shell: bash
       run: |
@@ -66,8 +66,8 @@ runs:
       uses: docker://pandoc/extra
       with:
         args: >-
-          -s -o ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
-          ./.github/workflows/bin/markdown/qlcplus-docs.md
+          -s -o ./.github/workflows/bin/temp/QLCplusDocumentation-${{ inputs.lang }}.pdf
+          ./.github/workflows/bin/markdown/qlcplus-docs-${{ inputs.lang }}.md
           --listings
           --pdf-engine=lualatex
           -V papersize=a4
@@ -102,7 +102,7 @@ runs:
     - name: Combine Title Page and Documentation PDFs
       shell: bash
       run: |
-        gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=./.github/workflows/bin/pdf/qlcplus-docs-${{ inputs.lang }}.pdf ./.github/workflows/bin/temp/titlepage.pdf ./.github/workflows/bin/temp/QLCplusDocumentation.pdf
+        gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile=./.github/workflows/bin/pdf/qlcplus-docs-${{ inputs.lang }}.pdf ./.github/workflows/bin/temp/titlepage.pdf ./.github/workflows/bin/temp/QLCplusDocumentation-${{ inputs.lang }}.pdf
     - name: Cleanup temporary items
       shell: bash
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: spellcheck
+name: documentation
 on:
   push:
   pull_request:
@@ -14,8 +14,27 @@ jobs:
           config_path: .spellcheck.yml
           task_name: Markdown
 
-  build-pdf:
+  detect-langs:
     runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.setlangs.outputs.langs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - id: setlangs
+        run: |
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([a-z][a-z]\)\.md/\1/p' | sort -u)
+          langs="en $langs"
+          json=$(printf '%s\n' $langs | jq -R . | jq -s .)
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
+  build-pdf:
+    needs: detect-langs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: ${{ fromJson(needs.detect-langs.outputs.langs) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,16 +42,16 @@ jobs:
       - id: build
         uses: ./.github/actions/build-pdf
         with:
-          lang: en
+          lang: ${{ matrix.lang }}
 
       - name: Upload-PDF
         uses: actions/upload-artifact@v4
         with:
-            name: qlcplus-docs-en-pdf
+            name: qlcplus-docs-${{ matrix.lang }}-pdf
             path: ./.github/workflows/bin/pdf/
-  
+
       - name: Upload-Markdown
         uses: actions/upload-artifact@v4
         with:
-            name: qlcplus-docs-en-markdown
+            name: qlcplus-docs-${{ matrix.lang }}-markdown
             path: ./.github/workflows/bin/markdown/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v4
       - id: setlangs
         run: |
-          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([a-z][a-z]\)\.md/\1/p' | sort -u)
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([A-Za-z][A-Za-z]\)\.md/\1/p' | tr '[:upper:]' '[:lower:]' | sort -u)
           langs="en $langs"
-          json=$(printf '%s\n' $langs | jq -R . | jq -s .)
+          json=$(printf '%s\n' $langs | jq -R . | jq -sc .)
           echo "langs=$json" >> "$GITHUB_OUTPUT"
 
   build-pdf:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/checkout@v4
       - id: setlangs
         run: |
-          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([a-z][a-z]\)\.md/\1/p' | sort -u)
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([A-Za-z][A-Za-z]\)\.md/\1/p' | tr '[:upper:]' '[:lower:]' | sort -u)
           langs="en $langs"
-          json=$(printf '%s\n' $langs | jq -R . | jq -s .)
+          json=$(printf '%s\n' $langs | jq -R . | jq -sc .)
           echo "langs=$json" >> "$GITHUB_OUTPUT"
 
   build_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,28 @@ permissions:
   contents: write
       
 jobs:
+  detect-langs:
+    runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.setlangs.outputs.langs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - id: setlangs
+        run: |
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([a-z][a-z]\)\.md/\1/p' | sort -u)
+          langs="en $langs"
+          json=$(printf '%s\n' $langs | jq -R . | jq -s .)
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
   build_release:
+    needs: detect-langs
     name: build_release
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: ${{ fromJson(needs.detect-langs.outputs.langs) }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -36,7 +55,7 @@ jobs:
       - id: build
         uses: ./.github/actions/build-pdf
         with:
-          lang: en
+          lang: ${{ matrix.lang }}
 
       - name: Upload PDF asset to release
         env:

--- a/scripts/Merge-MarkdownFiles.ps1
+++ b/scripts/Merge-MarkdownFiles.ps1
@@ -232,7 +232,7 @@ function Copy-ImagesToDirectory {
 
 $directoryPath  = "./pages/"                                                    # Path To Grav Documentation
 $imageDir       = "./.github/workflows/bin/markdown/images/"                        # Path to where images should go
-$outputFile     = "./.github/workflows/bin/markdown/qlcplus-docs.md"  # Path to where you want your damn markdown ;)
+$outputFile     = "./.github/workflows/bin/markdown/qlcplus-docs-$Lang.md"  # Path to where you want your damn markdown ;)
 
 
 # Move all image files into ./images so they can be found

--- a/scripts/Merge-MarkdownFiles.ps1
+++ b/scripts/Merge-MarkdownFiles.ps1
@@ -71,7 +71,7 @@ function Get-MarkdownFiles {
         [string]$Path,
         [string]$Lang
     )
-    Write-Host "Getting all markdown files from the $path directory..."
+    Write-Host "Getting all markdown files from the $path directory with language $Lang..."
     if (Test-Path $Path -PathType Container) {
         # Get the list of folders in the directory (feed is excluded as it's a stub for RSS)
         $folders = Get-ChildItem -Path $Path -Directory -Exclude feed
@@ -79,7 +79,7 @@ function Get-MarkdownFiles {
 
         # Iterate over each folder
         foreach ($folder in $folders) {
-            $chapterLocalized = Join-Path $folder.FullName "chapter.v4_${Lang}.md"
+            $chapterLocalized = Join-Path $folder.FullName "chapter.v4_$Lang.md"
             $chapterDefault   = Join-Path $folder.FullName "chapter.v4.md"
             if (Test-Path $chapterLocalized) {
                 $markdownFiles += Get-Item $chapterLocalized
@@ -90,9 +90,9 @@ function Get-MarkdownFiles {
             $docFiles = Get-ChildItem -Path $folder.FullName -Recurse -File | Where-Object { $_.Name -match "default\.v4\.md|docs\.md" }
             foreach ($doc in $docFiles) {
                 if ($doc.Name -eq 'docs.md') {
-                    $locName = "docs.v4_${Lang}.md"
+                    $locName = "docs.v4_$Lang.md"
                 } else {
-                    $locName = "$($doc.BaseName)_${Lang}.md"
+                    $locName = "$($doc.BaseName)_$Lang.md"
                 }
                 $locPath = Join-Path $doc.DirectoryName $locName
                 if (Test-Path $locPath) {


### PR DESCRIPTION
## Summary
- auto-detect available languages for PDF build matrix
- run PDF builds for each detected language in both main and release workflows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687060e4bb4c8325827c9247e607f470