### PR TITLE
Add dynamic PDF builds for all languages

### DIFF
--- a/.github/actions/build-pdf/action.yml
+++ b/.github/actions/build-pdf/action.yml
@@ -62,6 +62,22 @@ runs:
     - name: Put current date into a variable
       shell: bash
       run: echo "EXPORT_DATE=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
+      - name: Load title page translations
+        shell: bash
+        env:
+          DOC_LANG: ${{ inputs.lang }}
+          run: |
+            FILE=./scripts/titlepage_translations.json
+            TITLE=$(jq -r --arg l "$DOC_LANG" '.[$l].title // .en.title' "$FILE")
+            SUBTITLE=$(jq -r --arg l "$DOC_LANG" '.[$l].subtitle // .en.subtitle' "$FILE")
+            AUTHOR=$(jq -r --arg l "$DOC_LANG" '.[$l].author // .en.author' "$FILE")
+            WRITTEN_BY=$(jq -r --arg l "$DOC_LANG" '.[$l].written_by // .en.written_by' "$FILE")
+            RELEASE_PREFIX=$(jq -r --arg l "$DOC_LANG" '.[$l].release_prefix // .en.release_prefix' "$FILE")
+            echo "TITLE=$TITLE" >> $GITHUB_ENV
+            echo "SUBTITLE=$SUBTITLE" >> $GITHUB_ENV
+            echo "AUTHOR=$AUTHOR" >> $GITHUB_ENV
+            echo "WRITTEN_BY=$WRITTEN_BY" >> $GITHUB_ENV
+            echo "RELEASE_PREFIX=$RELEASE_PREFIX" >> $GITHUB_ENV
     - name: Build PDF
       uses: docker://pandoc/extra
       with:
@@ -94,9 +110,11 @@ runs:
           --verbose
           -V mainfont="Source Sans Pro"
           -V sansfont="Source Sans Pro"
-          -V title="Q Light Controller + Documentation"
-          -V subtitle="Comprehensive Guide"
-          -V author="docs.qlcplus.org"
+          -V title="${{ env.TITLE }}"
+          -V subtitle="${{ env.SUBTITLE }}"
+          -V author="${{ env.AUTHOR }}"
+          -V written_by="${{ env.WRITTEN_BY }}"
+          -V release_prefix="${{ env.RELEASE_PREFIX }}"
           -V date="${{ env.EXPORT_DATE }}"
           -V release="${{ env.LATEST_RELEASE }}"
     - name: Combine Title Page and Documentation PDFs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: spellcheck
+name: documentation
 on:
   push:
   pull_request:
@@ -14,8 +14,27 @@ jobs:
           config_path: .spellcheck.yml
           task_name: Markdown
 
-  build-pdf:
+  detect-langs:
     runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.setlangs.outputs.langs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - id: setlangs
+        run: |
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([A-Za-z][A-Za-z]\)\.md/\1/p' | tr '[:upper:]' '[:lower:]' | sort -u)
+          langs="en $langs"
+          json=$(printf '%s\n' $langs | jq -R . | jq -sc .)
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
+  build-pdf:
+    needs: detect-langs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: ${{ fromJson(needs.detect-langs.outputs.langs) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,16 +42,16 @@ jobs:
       - id: build
         uses: ./.github/actions/build-pdf
         with:
-          lang: en
+          lang: ${{ matrix.lang }}
 
       - name: Upload-PDF
         uses: actions/upload-artifact@v4
         with:
-            name: qlcplus-docs-en-pdf
+            name: qlcplus-docs-${{ matrix.lang }}-pdf
             path: ./.github/workflows/bin/pdf/
-  
+
       - name: Upload-Markdown
         uses: actions/upload-artifact@v4
         with:
-            name: qlcplus-docs-en-markdown
+            name: qlcplus-docs-${{ matrix.lang }}-markdown
             path: ./.github/workflows/bin/markdown/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,8 +50,8 @@ jobs:
             name: qlcplus-docs-${{ matrix.lang }}-pdf
             path: ./.github/workflows/bin/pdf/
 
-      - name: Upload-Markdown
-        uses: actions/upload-artifact@v4
-        with:
-            name: qlcplus-docs-${{ matrix.lang }}-markdown
-            path: ./.github/workflows/bin/markdown/
+#      - name: Upload-Markdown
+#        uses: actions/upload-artifact@v4
+#        with:
+#            name: qlcplus-docs-${{ matrix.lang }}-markdown
+#            path: ./.github/workflows/bin/markdown/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,28 @@ permissions:
   contents: write
       
 jobs:
+  detect-langs:
+    runs-on: ubuntu-latest
+    outputs:
+      langs: ${{ steps.setlangs.outputs.langs }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - id: setlangs
+        run: |
+          langs=$(find pages -name '*_??.md' | sed -n 's/.*_\([A-Za-z][A-Za-z]\)\.md/\1/p' | tr '[:upper:]' '[:lower:]' | sort -u)
+          langs="en $langs"
+          json=$(printf '%s\n' $langs | jq -R . | jq -sc .)
+          echo "langs=$json" >> "$GITHUB_OUTPUT"
+
   build_release:
+    needs: detect-langs
     name: build_release
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lang: ${{ fromJson(needs.detect-langs.outputs.langs) }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -36,7 +55,7 @@ jobs:
       - id: build
         uses: ./.github/actions/build-pdf
         with:
-          lang: en
+          lang: ${{ matrix.lang }}
 
       - name: Upload PDF asset to release
         env:

--- a/pages/10.fixture-definition-editor/chapter.v4_de.md
+++ b/pages/10.fixture-definition-editor/chapter.v4_de.md
@@ -18,7 +18,7 @@ Um Ihre Fixture-Definitionen in QLC+ zu verwenden, müssen Sie sie an einem Ort 
 1. Im selben Ordner wie Ihr QLC+-Arbeitsbereich (praktisch, wenn Sie Ihren Arbeitsbereich jemand anderem geben möchten)
 2. Im Benutzer-Fixtures-Ordner an folgenden Orten:
     * Linux: Es handelt sich um einen versteckten Ordner in Ihrem Benutzer-Home-Verzeichnis: „$HOME/.qlcplus/Fixtures“.
-    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: „C:\\Benutzer\{Benutzername}\QLC+\Fixtures“.
+    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\{Benutzername}\QLC+\Fixtures`.
     * Mac OS: Es befindet sich in Ihrem Benutzerbibliotheksverzeichnis: „$HOME/Library/Application\\ Support/QLC+/Fixtures“.
 	
 **Wichtiger Hinweis: Sie sollten Ihre benutzerdefinierten Geräte NICHT im Geräteordner des QLC+-Systems speichern oder kopieren. Dies liegt daran, dass bei der Deinstallation von QLC+ alle Geräte in diesem Ordner gelöscht werden. Es kann auch zu unbeabsichtigten Konflikten zwischen dem System und Ihren eigenen Gerätedefinitionen kommen.**

--- a/pages/10.fixture-definition-editor/chapter.v4_de.md
+++ b/pages/10.fixture-definition-editor/chapter.v4_de.md
@@ -18,7 +18,7 @@ Um Ihre Fixture-Definitionen in QLC+ zu verwenden, müssen Sie sie an einem Ort 
 1. Im selben Ordner wie Ihr QLC+-Arbeitsbereich (praktisch, wenn Sie Ihren Arbeitsbereich jemand anderem geben möchten)
 2. Im Benutzer-Fixtures-Ordner an folgenden Orten:
     * Linux: Es handelt sich um einen versteckten Ordner in Ihrem Benutzer-Home-Verzeichnis: „$HOME/.qlcplus/Fixtures“.
-    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\<Benutzername>\QLC+\Fixtures`.
+    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\\Benutzer\\<Benutzername>\\QLC+\\Fixtures`.
     * Mac OS: Es befindet sich in Ihrem Benutzerbibliotheksverzeichnis: „$HOME/Library/Application\\ Support/QLC+/Fixtures“.
 	
 **Wichtiger Hinweis: Sie sollten Ihre benutzerdefinierten Geräte NICHT im Geräteordner des QLC+-Systems speichern oder kopieren. Dies liegt daran, dass bei der Deinstallation von QLC+ alle Geräte in diesem Ordner gelöscht werden. Es kann auch zu unbeabsichtigten Konflikten zwischen dem System und Ihren eigenen Gerätedefinitionen kommen.**

--- a/pages/10.fixture-definition-editor/chapter.v4_de.md
+++ b/pages/10.fixture-definition-editor/chapter.v4_de.md
@@ -18,7 +18,7 @@ Um Ihre Fixture-Definitionen in QLC+ zu verwenden, müssen Sie sie an einem Ort 
 1. Im selben Ordner wie Ihr QLC+-Arbeitsbereich (praktisch, wenn Sie Ihren Arbeitsbereich jemand anderem geben möchten)
 2. Im Benutzer-Fixtures-Ordner an folgenden Orten:
     * Linux: Es handelt sich um einen versteckten Ordner in Ihrem Benutzer-Home-Verzeichnis: „$HOME/.qlcplus/Fixtures“.
-    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\{Benutzername}\QLC+\Fixtures`.
+    * Windows: Es ist ein Ordner in Ihrem Benutzerverzeichnis: `C:\Benutzer\<Benutzername>\QLC+\Fixtures`.
     * Mac OS: Es befindet sich in Ihrem Benutzerbibliotheksverzeichnis: „$HOME/Library/Application\\ Support/QLC+/Fixtures“.
 	
 **Wichtiger Hinweis: Sie sollten Ihre benutzerdefinierten Geräte NICHT im Geräteordner des QLC+-Systems speichern oder kopieren. Dies liegt daran, dass bei der Deinstallation von QLC+ alle Geräte in diesem Ordner gelöscht werden. Es kann auch zu unbeabsichtigten Konflikten zwischen dem System und Ihren eigenen Gerätedefinitionen kommen.**

--- a/pages/11.advanced/05.custom-ui-style/default.v4_de.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_de.md
@@ -13,7 +13,7 @@ Der Dateiname ist in QLC+ fest codiert und muss lauten: „qlcplusStyle.qss“.
 Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:  
 
 * **Linux**: `$HOME/.qlcplus`
-* **Windows**: „C:\\Benutzer\{Benutzername}\QLC+“.
+* **Windows**: `C:\Benutzer\{Benutzername}\QLC+`.
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
 Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.  

--- a/pages/11.advanced/05.custom-ui-style/default.v4_de.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_de.md
@@ -13,7 +13,7 @@ Der Dateiname ist in QLC+ fest codiert und muss lauten: „qlcplusStyle.qss“.
 Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:  
 
 * **Linux**: `$HOME/.qlcplus`
-* **Windows**: `C:\Benutzer\<Benutzername>\QLC+`.
+* **Windows**: `C:\\Benutzer\\<Benutzername>\\QLC+`.
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
 Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.  

--- a/pages/11.advanced/05.custom-ui-style/default.v4_de.md
+++ b/pages/11.advanced/05.custom-ui-style/default.v4_de.md
@@ -13,7 +13,7 @@ Der Dateiname ist in QLC+ fest codiert und muss lauten: „qlcplusStyle.qss“.
 Die Stildatei muss außerdem in einem bestimmten Pfad abgelegt werden:  
 
 * **Linux**: `$HOME/.qlcplus`
-* **Windows**: `C:\Benutzer\{Benutzername}\QLC+`.
+* **Windows**: `C:\Benutzer\<Benutzername>\QLC+`.
 * **OSX**: `$HOME/Library/Application\\ Support/QLC+`
 
 Die Theme-Datei ist in Abschnitte unterteilt. Jeder Abschnitt stellt die UI-Elemente dar, die beim Ausführen von QLC+ geändert werden. Unveränderte Abschnitte können weggelassen werden.  

--- a/scripts/Merge-MarkdownFiles.ps1
+++ b/scripts/Merge-MarkdownFiles.ps1
@@ -1,5 +1,5 @@
-param([string]$Lang="EN")
-$Lang = $Lang.ToUpper()
+param([string]$Lang="en")
+$Lang = $Lang.ToLower()
 
 function Update-MarkdownHeadingLevels {
     param (

--- a/scripts/template.tex
+++ b/scripts/template.tex
@@ -46,13 +46,13 @@
         % Conditional release rendering
         \ifx\release\empty
         \else
-            {\Huge \textit{Release: $release$}} \\
+            {\Huge \textit{$release_prefix$ $release$}} \\
         \fi
         \vfill
         % Custom "Written by..." message above the author
         \ifx\author\empty
         \else
-            {\Large \textit{Written by... you!}} \\  % Custom message
+            {\Large \textit{$written_by$}} \\  % Custom message
             {\Large $author$} \\  % Author's name
         \fi
         \vfill

--- a/scripts/titlepage_translations.json
+++ b/scripts/titlepage_translations.json
@@ -1,0 +1,23 @@
+{
+  "en": {
+    "title": "Q Light Controller + Documentation",
+    "subtitle": "Comprehensive Guide",
+    "author": "docs.qlcplus.org",
+    "written_by": "Written by... you!",
+    "release_prefix": "Release:"
+  },
+  "de": {
+    "title": "Q Light Controller + Dokumentation",
+    "subtitle": "Umfassender Leitfaden",
+    "author": "docs.qlcplus.org",
+    "written_by": "Geschrieben von... dir!",
+    "release_prefix": "Version:"
+  },
+  "ca": {
+    "title": "Documentació de Q Light Controller +",
+    "subtitle": "Guia completa",
+    "author": "docs.qlcplus.org",
+    "written_by": "Escrit per... tu!",
+    "release_prefix": "Versió:"
+  }
+}


### PR DESCRIPTION
## Summary
- auto-detect available languages for PDF build matrix
- run PDF builds for each detected language in both main and release workflows
- handle uppercase codes and compact matrix JSON

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687060e4bb4c8325827c9247e607f470